### PR TITLE
correção na nav

### DIFF
--- a/components/Header/index.jsx
+++ b/components/Header/index.jsx
@@ -38,21 +38,9 @@ export default function Header() {
           <CloseSidebar onClick={showSidebar}>
             <FaTimes />
           </CloseSidebar>
-          <Link href="/">
-            <Ancora className={activeLink("")} onClick={showSidebar}>
-              Home
-            </Ancora>
-          </Link>
-          <Link href="projects">
-            <Ancora className={activeLink("projects")} onClick={showSidebar}>
-              Projects
-            </Ancora>
-          </Link>
-          <Link href="Contact">
-            <Ancora className={activeLink("contact")} onClick={showSidebar}>
-              Contact
-            </Ancora>
-          </Link>
+          <Link href="/">Home</Link>
+          <Link href="/projects">Projects</Link>
+          <Link href="/contact">Cotnact</Link>
         </NavLinks>
       </Content>
     </Container>


### PR DESCRIPTION
Correção nos caminhos da navbar, remoção do componente Ancora (uma estilização da tag a) pois não havia necessidade dele dentro de um componente Link. Resta apenas corrigir a estilização, transferindo o conteúdo do componente Ancora para Link.